### PR TITLE
Move change directory command to optional step

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Everything is neatly packed in the **QuestionGeneration.zip** bundled with the c
 
 	`unzip QuestionGeneration.zip`
 
-	`cd QuestionGeneration`
-
 3. [Optional] Start two servers to speed up the script, Stanford Parser server and the SST servers in two separate terminals.
+
+	`cd QuestionGeneration`
 
 	`bash runStanfordParserServer.sh`
 


### PR DESCRIPTION
The users only need to be inside the QuestionsGeneration directory if they're planning the run the server scripts.